### PR TITLE
Proviral landscape plots

### DIFF
--- a/Singularity
+++ b/Singularity
@@ -13,7 +13,7 @@ From: centos:7
     MAINTAINER BC CfE in HIV/AIDS https://github.com/cfe-lab/
     KIVE_INPUTS sample_info_csv contigs_csv conseqs_csv cascade_csv
     KIVE_OUTPUTS outcome_summary_csv conseqs_primers_csv contigs_primers_csv \
-        table_precursor_csv hivseqinr_results_tar
+        table_precursor_csv proviral_landscape_csv hivseqinr_results_tar
     KIVE_THREADS 1
     KIVE_MEMORY 6000
 

--- a/gene_splicer/sample.py
+++ b/gene_splicer/sample.py
@@ -103,7 +103,7 @@ def main():
     for file in fasta_files:
         gene_splicer.run(file, outdir=outpath)
     utils.generate_table_precursor(name=run_name, outpath=outpath)
-    utils.generate_proviral_landscape_csv(name=run_name, outpath=outpath)
+    utils.generate_proviral_landscape_csv(outpath)
     copy_output(outpath / 'outcome_summary.csv', args.outcome_summary_csv)
     copy_output(outpath / (run_name + '_conseqs_primer_analysis.csv'),
                 args.conseqs_primers_csv)

--- a/gene_splicer/sample.py
+++ b/gene_splicer/sample.py
@@ -40,6 +40,9 @@ def parse_args():
     parser.add_argument('table_precursor_csv',
                         help='Sequence data ready to upload',
                         type=FileType('w'))
+    parser.add_argument('proviral_landscape_csv',
+                        help='Data for proviral landscape plot',
+                        type=FileType('w'))
     parser.add_argument('hivseqinr_results_tar',
                         help="Archive file with HIVSeqinR's final results folder.",
                         type=FileType('wb'))
@@ -100,12 +103,14 @@ def main():
     for file in fasta_files:
         gene_splicer.run(file, outdir=outpath)
     utils.generate_table_precursor(name=run_name, outpath=outpath)
+    utils.generate_proviral_landscape_csv(name=run_name, outpath=outpath)
     copy_output(outpath / 'outcome_summary.csv', args.outcome_summary_csv)
     copy_output(outpath / (run_name + '_conseqs_primer_analysis.csv'),
                 args.conseqs_primers_csv)
     copy_output(outpath / (run_name + '_contigs_primer_analysis.csv'),
                 args.contigs_primers_csv)
     copy_output(outpath / 'table_precursor.csv', args.table_precursor_csv)
+    copy_output(outpath / 'proviral_landscape.csv', args.proviral_landscape_csv)
 
 
 if __name__ == '__main__':

--- a/gene_splicer/utils.py
+++ b/gene_splicer/utils.py
@@ -531,7 +531,7 @@ def generate_proviral_landscape_csv(outpath):
             if row['qseqid'] in ['8E5LAV', 'HXB2']:
                 # skip the positive control rows
                 continue
-            if row['send'] < 638 or row['sstart'] > 9632:
+            if int(row['send']) < 638 or int(row['sstart']) > 9632:
                 # skip unspecific matches of LTR at start and end
                 continue
             [run_name, sample_name, _, _] = row['qseqid'].split('::')

--- a/gene_splicer/utils.py
+++ b/gene_splicer/utils.py
@@ -565,7 +565,7 @@ def generate_proviral_landscape_csv(outpath):
                 if entry['samp_name'] == samp_name:
                     entry['defect'] = verdict
 
-    landscape_columns = ['samp_name', 'run_name', 'ref_start', 'ref_end', 'defect', 'highlighted']
+    landscape_columns = ['samp_name', 'run_name', 'ref_start', 'ref_end', 'defect', 'is_inverted', 'is_defective']
     with open(proviral_landscape_csv, 'w') as landscape_file:
         landscape_writer = csv.DictWriter(landscape_file, fieldnames=landscape_columns)
         landscape_writer.writeheader()

--- a/gene_splicer/utils.py
+++ b/gene_splicer/utils.py
@@ -538,7 +538,9 @@ def generate_proviral_landscape_csv(outpath):
             landscape_entry = {'ref_start': row['sstart'],
                                'ref_end': row['send'],
                                'samp_name': sample_name,
-                               'samp_id': f"{run_name}::{sample_name}"}
+                               'run_name': run_name,
+                               'highlighted': ''}
+            # highlighted is empty for now: can be filled manually
             landscape_rows.append(landscape_entry)
 
     with open(table_precursor_csv, 'r') as tab_prec:
@@ -550,10 +552,7 @@ def generate_proviral_landscape_csv(outpath):
                 if entry['samp_name'] == samp_name:
                     entry['defect'] = verdict
 
-    for entry in landscape_rows:
-        del entry['samp_name']
-
-    landscape_columns = ['samp_id', 'ref_start', 'ref_end', 'defect']
+    landscape_columns = ['samp_id', 'run_name', 'ref_start', 'ref_end', 'defect', 'highlighted']
     with open(proviral_landscape_csv, 'w') as landscape_file:
         landscape_writer = csv.DictWriter(landscape_file, fieldnames=landscape_columns)
         landscape_writer.writerows(landscape_rows)

--- a/gene_splicer/utils.py
+++ b/gene_splicer/utils.py
@@ -531,9 +531,10 @@ def generate_proviral_landscape_csv(outpath):
             if row['qseqid'] in ['8E5LAV', 'HXB2']:
                 # skip the positive control rows
                 continue
-            # TODO: have to skip weird entries at start and end
-            print(row['qseqid'])
-            [run_name, sample_name, reference, seqtype] = row['qseqid'].split('::')
+            if row['send'] < 638 or row['sstart'] > 9632:
+                # skip unspecific matches of LTR at start and end
+                continue
+            [run_name, sample_name, _, _] = row['qseqid'].split('::')
             landscape_entry = {'ref_start': row['sstart'],
                                'ref_end': row['send'],
                                'samp_name': sample_name,

--- a/gene_splicer/utils.py
+++ b/gene_splicer/utils.py
@@ -549,6 +549,9 @@ def generate_proviral_landscape_csv(outpath):
                 if entry['samp_name'] == samp_name:
                     entry['defect'] = verdict
 
+    for entry in landscape_rows:
+        del entry['samp_name']
+
     landscape_columns = ['samp_id', 'ref_start', 'ref_end', 'defect']
     with open(proviral_landscape_csv, 'w') as landscape_file:
         landscape_writer = csv.DictWriter(landscape_file, fieldnames=landscape_columns)

--- a/gene_splicer/utils.py
+++ b/gene_splicer/utils.py
@@ -551,6 +551,7 @@ def generate_proviral_landscape_csv(outpath):
     landscape_columns = ['samp_id', 'ref_start', 'ref_end', 'defect']
     with open(proviral_landscape_csv, 'w') as landscape_file:
         landscape_writer = csv.DictWriter(landscape_file, fieldnames=landscape_columns)
+        landscape_writer.writerows(landscape_rows)
 
 
 def get_softclipped_region(query, alignment, alignment_path):

--- a/gene_splicer/utils.py
+++ b/gene_splicer/utils.py
@@ -552,7 +552,7 @@ def generate_proviral_landscape_csv(outpath):
                 if entry['samp_name'] == samp_name:
                     entry['defect'] = verdict
 
-    landscape_columns = ['samp_id', 'run_name', 'ref_start', 'ref_end', 'defect', 'highlighted']
+    landscape_columns = ['samp_name', 'run_name', 'ref_start', 'ref_end', 'defect', 'highlighted']
     with open(proviral_landscape_csv, 'w') as landscape_file:
         landscape_writer = csv.DictWriter(landscape_file, fieldnames=landscape_columns)
         landscape_writer.writerows(landscape_rows)

--- a/gene_splicer/utils.py
+++ b/gene_splicer/utils.py
@@ -526,13 +526,14 @@ def generate_proviral_landscape_csv(outpath):
                       'stitle',
                       'sstrand']
     with open(blastn_csv, 'r') as blastn_file:
-        blastn_reader = DictReader(blastn_file, fieldnames=blastn_columns)
+        blastn_reader = DictReader(blastn_file, fieldnames=blastn_columns, delimiter='\t')
         for row in blastn_reader:
             if row['qseqid'] in ['8E5LAV', 'HXB2']:
                 # skip the positive control rows
                 continue
             # TODO: have to skip weird entries at start and end
-            [run_name, sample_name, reference, seqtype] = row['seqid'].split('::', expand=True)
+            print(row['qseqid'])
+            [run_name, sample_name, reference, seqtype] = row['qseqid'].split('::')
             landscape_entry = {'ref_start': row['sstart'],
                                'ref_end': row['send'],
                                'samp_name': sample_name,

--- a/gene_splicer/utils.py
+++ b/gene_splicer/utils.py
@@ -555,6 +555,7 @@ def generate_proviral_landscape_csv(outpath):
     landscape_columns = ['samp_name', 'run_name', 'ref_start', 'ref_end', 'defect', 'highlighted']
     with open(proviral_landscape_csv, 'w') as landscape_file:
         landscape_writer = csv.DictWriter(landscape_file, fieldnames=landscape_columns)
+        landscape_writer.writeheader()
         landscape_writer.writerows(landscape_rows)
 
 


### PR DESCRIPTION
Create a new output file, `proviral_landscape.csv`, which contains information about the blast matches (from an intermediate file produced by HIVSeqinR) as well as the defect category (from the column `MyVerdict` in `table_precursor.csv`). This file can be used to generate proviral landscape plots with a tool located on the BBlabtools website - it needs to be generated in a separate step to allow researchers to combine data that is spread across several runs, and to manually add or modify the data in the file.

Closes #16